### PR TITLE
Fix Python 3.12 compatibility by upgrading setuptools requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,5 @@ dev = ["check-manifest", "pytest"]
 "Source Code" = "https://github.com/fastdatascience/faststylometry"
 
 [build-system]
-requires = ["setuptools>=46.4.0", "wheel", "twine"]
+requires = ["setuptools>=68.0.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,5 @@ dev = ["check-manifest", "pytest"]
 "Source Code" = "https://github.com/fastdatascience/faststylometry"
 
 [build-system]
-requires = ["setuptools>=66.1.0", "wheel"]
+requires = ["setuptools>=66.1.0", "wheel", "twine"]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,5 @@ dev = ["check-manifest", "pytest"]
 "Source Code" = "https://github.com/fastdatascience/faststylometry"
 
 [build-system]
-requires = ["setuptools>=68.0.0", "wheel"]
+requires = ["setuptools>=66.1.0", "wheel"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
Fixes #5 

This PR resolves the `AttributeError: module 'pkgutil' has no attribute 'ImpImporter'` error that occurs when installing faststylometry on Python 3.12+.

## Root Cause
Python 3.12 removed the deprecated `pkgutil.ImpImporter` class. The previous setuptools requirement (`>=46.4.0`) allowed versions that still reference this removed class during the build process, causing installation failures.

## Changes
- Updated setuptools requirement from `>=46.4.0` to `>=66.1.0` in `pyproject.toml`

## Why 66.1.0?
This is the earliest setuptools version that fixes the `pkgutil.ImpImporter` issue ([setuptools#3685](https://github.com/pypa/setuptools/issues/3685)). Using the minimum compatible version provides better backwards compatibility.

## Impact
This eliminates the need for the numpy downgrade workaround currently documented in the README (lines 44-64).

## Testing
- ✅ Successfully tested installation on Python 3.12.3 with setuptools 66.1.0
- ✅ Package builds without errors
- ✅ Package imports correctly
- ✅ Basic functionality verified
- ✅ All dependencies install without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)